### PR TITLE
Add Mist — free macOS-style screenshot & sharing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [LICEcap](http://www.cockos.com/licecap/) - Animated screen captures and save them directly to .GIF
 - [LightBulb](https://github.com/Tyrrrz/LightBulb) - Reduces eyestrain by adjusting gamma based on the current time
 - [Link Shell Extension](http://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html) - Create symlinks from Explorer.
+- [Mist](https://getmist.app) - Free macOS-style screenshot and screen recording tool with instant cloud sharing for Windows. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [PowerPlanSwitcher](https://www.microsoft.com/en-us/store/p/powerplanswitcher/9nblggh556l3) - Provides a quick UI for switching power schemas & automatic switch on AC-plug-in on Windows10. [![Open-Source Software][oss icon]](https://github.com/petrroll/PowerSwitcher)
 - [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer) - Discover which program has a particular file or directory open. Process Explorer shows you information about which handles and DLLs processes have opened or loaded.
 - [qBittorrent](https://qbittorrent.org/) - Free and reliable P2P Bittorrent client.


### PR DESCRIPTION
Mist is a free Windows screenshot and screen recording tool that replicates the macOS Cmd+Shift+4 experience. It lives in the system tray, activates on a hotkey, and lets you capture regions, windows, or full screens. Floating thumbnail for quick copy/drag-to-share. Pro adds instant shareable links.

- Site: https://getmist.app
- Download: https://www.getmist.app (free, ~15 MB, Windows 10/11)
- Category: Screenshots / Screen Capture / Utilities

Added in alphabetical order in the Utilities section (between Link Shell Extension and PowerPlanSwitcher).