### PR TITLE
Added Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [Acrylic DNS Proxy](http://mayakron.altervista.org/wikibase/show.php?id=AcrylicHome) - A local DNS proxy which caches the responses coming from your DNS servers and helps you fight unwanted ads through a custom HOSTS file. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [AdwCleaner](https://toolslib.net/downloads/viewdownload/1-adwcleaner/) - Free removal tool for adware, PUP/LPI, Toolbars and Hijacker. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Bitdefender](http://www.bitdefender.com/) - Best outright protection against malware.
+- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - A CLI tool to extract server certificates from a URL. [![Open-Source Software][oss icon]](https://github.com/Hakky54/certificate-ripper) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Cryptomator](https://cryptomator.org/) - Free client-side encryption for your cloud files. [![Open-Source Software][oss icon]](https://github.com/cryptomator/cryptomator) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Disable Data Logging](https://www.reddit.com/r/Windows10/comments/3f38ed/guide_how_to_disable_data_logging_in_w10) - Make Windows 10 more private and safe. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [ENCRYPTO](http://macpaw.com/encrypto) - Encrypt your files in an elegant way. ![Freeware][freeware icon] ![Freeware][freeware icon light]


### PR DESCRIPTION
Certificate Ripper is a lightweight, easy-to-use CLI tool that allows developers and security engineers to extract and inspect SSL/TLS certificates from remote servers directly from the terminal — no browser or GUI required.

Working with certificates is a common task when debugging HTTPS connectivity issues, verifying certificate chains, or auditing expiry dates across environments. While tools like OpenSSL can do this, they require verbose and hard-to-remember commands. Certificate Ripper offers a simpler, more developer-friendly
experience with support for multiple export formats (PEM, PKCS12, and more)