### PR TITLE
Add treepp to Terminal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [Putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) - SSH and telnet client.
 - [Terminus](https://eugeny.github.io/terminus/) - modern, highly configurable terminal app based on web technologies. [![Open-Source Software][oss icon]](https://github.com/Eugeny/terminus) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Warp](https://www.warp.dev/) - Warp is a modern, Rust-based terminal with AI built in so you and your team can build great software, faster. ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [treepp](https://github.com/Water-Run/treepp) - A modern Windows `tree` replacement with diff-level compatibility, modern features like `.gitignore` support, and significantly faster performance.
 - [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal-preview/9n0dx20hk701) - Microsoft's official new terminal for Windows. [![Open-Source Software][oss icon]](https://github.com/microsoft/terminal) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Yaw](https://yaw.sh) - A cross-platform terminal with built-in file editor, SSH client, connection manager, and AI assistant.
 


### PR DESCRIPTION
This PR adds `treepp` to the Terminal section. It is a modern, high-performance replacement for the legacy Windows `tree` command.

**Key Improvements:**
1. **Full Compatibility on Successful Runs:** It achieves diff-level, bit-for-bit output parity with the original Windows `tree` command when executing successfully, ensuring a seamless drop-in experience.
2. **Modern Features for Modern Projects:** The native 40-year-old `tree.com` only provides two basic flags (`/a` and `/f`), making it practically unusable for modern development environments (e.g., scanning a Node.js project with huge `node_modules`). `treepp` fixes this by adding essential features such as `.gitignore` support, custom file/directory exclusions, depth limitation, and structured output (JSON, YAML, TOML).
3. **High Performance:** Implemented in Rust, it delivers several times faster scanning performance compared to the native `tree`.

The project is already featured in the official `awesome-rust` list.