### PR TITLE
Add Instafill.ai under Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 ### Documents
 
 - [FreeOffice](http://www.freeoffice.com/en/) - FreeOffice is a complete office suite with a word processor, a spreadsheet application and a presentation program – all compatible with their counterparts in Microsoft Office. ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [Instafill.ai](https://instafill.ai) - AI-powered PDF form filler. Auto-completes any PDF form by extracting fields and filling from saved profiles, uploaded files, or supplied data.
 - [LibreOffice](https://www.libreoffice.org/) - Open source office suite. [![Open-Source Software][oss icon]](https://www.libreoffice.org/about-us/source-code/) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Microsoft Office](http://www.office.com) - Microsoft's own productivity suite.
 - [NitroPDF](https://www.gonitro.com/pdf-reader) - The best PDF Reader you'll ever get.


### PR DESCRIPTION
Adding [Instafill.ai](https://instafill.ai) under **Applications → Documents** (alphabetical position between FreeOffice and LibreOffice).

Instafill.ai is an AI-powered PDF form filler for Windows — uploads a form, extracts fields, and completes them from a saved profile or supplied data. Fits the Documents section alongside the office suites and PDF tools already listed.