### PR TITLE
Add ChatCrystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 ### Developer Tools
 
 - [Cacher](https://www.cacher.io/) - Cloud-based, team-enabled code snippet manager with Gist sync, VSCode/Atom/Sublime packages and full-featured web client.
+- [ChatCrystal](https://zengliangyi.github.io/ChatCrystal/) - Local-first Windows desktop app that turns AI coding conversations into searchable knowledge notes. [![Open-Source Software][oss icon]](https://github.com/ZengLiangYi/ChatCrystal) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [DB Browser for SQLite](http://sqlitebrowser.org/) - High quality, visual, open source tool to create, design, and edit database files compatible with SQLite [![Open-Source Software][oss icon]](http://sqlitebrowser.org/)
 - [ExtendsClass](https://extendsclass.com/) - Online tools for developers (REST/SOAP clients, SQLite browser, Regex tester, XPath tester) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Fiddler](http://www.telerik.com/fiddler) - Web debugging proxy.


### PR DESCRIPTION
Adds [ChatCrystal](https://zengliangyi.github.io/ChatCrystal/), a local-first Windows desktop app for turning AI coding conversations into searchable knowledge notes. It is open source and fits the Developer Tools category.