### PR TITLE
Add ShotsGlow to the list of utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [SDelete](https://technet.microsoft.com/en-us/sysinternals/sdelete.aspx) - A command line utility that can securely delete a file, or clean the slack space.
 - [SetToStartup](https://aashutoshrathi.github.io/Python-Scripts-and-Games/SetToStartup/) - This script will help you to add your favorite programs or self made scripts/folders to startup. [![Open-Source Software][oss icon]](https://aashutoshrathi.github.io/Python-Scripts-and-Games/SetToStartup/)
 - [ShareX](https://getsharex.com/)- Lets you take screenshots or screencasts of any selected area with a single key. [![Open-Source Software][oss icon]](https://github.com/ShareX/ShareX) ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [ShotsGlow](https://shotsglow.com/) - Capture a region, drop it onto a gradient backdrop, annotate, blur/redact (survives a later crop), and remove image backgrounds with an on-device AI model. Paid, no subscription.
 - [SpaceMonger](https://spacemonger.en.softonic.com/download) - A graphical utility to display folders and files in blocks relative to their disk usage.
 - [Speccy](https://www.piriform.com/speccy) -Detailed statistics on every piece of hardware in your computer.
 - [SpeedCrunch](http://speedcrunch.org/) - The best and only calculator you'll need, completely stripped down of unnecessary UI clutter. [![Open-Source Software][OSS Icon]](https://bitbucket.org/heldercorreia/speedcrunch/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding my native Windows screenshot tool, ShotsGlow. Capture → gradient backdrop → annotate/redact → on-device AI background removal (runs offline, nothing uploaded). Paid, $9 one-time, no subscription. Placed in Utilities after ShareX to keep it alphabetical, no badge since it's not free/OSS.