### PR TITLE
Add Focusd to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [f.lux](http://stereopsis.com/flux/) - Automatically adjust your computer screen to match lighting. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [File Juggler](https://www.filejuggler.com/) - Organize files automatically. Monitor folders and execute actions like rename, delete, unzip and more. Finds dates in PDFs and much more.
 - [Files](https://files.community/) - A modern file manager that helps users organize their files and folders. [![Open-Source Software][oss icon]](https://github.com/files-community/Files) ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [Focusd](https://focusd.0xarchit.is-a.dev) - A local, privacy-first CLI screen time monitor. [![Open-Source Software][oss icon]](https://github.com/0xarchit/Focusd) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Inkdrop](https://www.inkdrop.info/) - The note-taking app for Markdown lovers.
 - [KatMouse](http://www.ehiti.de/katmouse/) - Utility that enables "universal scrolling" in Windows: scrolling does not need the window to be active/clicked first (i.e. how it works in macOS and Linux) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Keypirinha](http://keypirinha.com/) - A fast launcher for keyboard ninjas on Windows. You can think of Keypirinha as an alternative to _Launchy_ and a cousin of _Alfred_. ![Freeware][freeware icon] ![Freeware][freeware icon light]


### PR DESCRIPTION
Adding Focusd, an open-source, local-only CLI screen time monitor, to the Productivity section. 

- [x] Checked for duplicates.
- [x] Placed alphabetically.
- [x] OSS icon included linking to the repository.
- [x] Trailing whitespace removed.