### PR TITLE
Add NeatCopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [Listary](http://www.listary.com/) - Keep files at your fingertips. An unique search utility.
 - [Luna](https://github.com/adrianmteo/Luna) - Automatic dark mode for Windows 10.
 - [MultiCommander](http://multicommander.com/) - File Manager for Professionals. ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [NeatCopy](https://stonell1.github.io/neatcopy-website/) - Windows tray clipboard text processor with local cleanup rules and LLM prompts. [![Open-Source Software][oss icon]](https://github.com/StoneLL1/NeatCopy) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Ninite](https://ninite.com/) - The easiest, fastest way to update or install software. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [One Commander](http://onecommander.com/) - File manager featuring miller columns and dual-pane views. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [RightWheel](https://chautnus.github.io/RightWheel/) - Mouse shortcut panel for Windows — hold right-click and scroll to instantly launch apps, trigger shortcuts, run commands and open URLs without touching the keyboard. Supports folder submenus, shell commands, import templates, and 9 languages. Portable single .exe, no install required.


### PR DESCRIPTION
Adds NeatCopy to Applications > Productivity. The entry is placed alphabetically and uses the open-source/freeware markers described in Contributing.md.