### PR TITLE
Add Agent Island to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 
 ### Developer Tools
 
+- [Agent Island](https://agent-island.dev/) - Status companion for Claude Code and Codex with session state and your-turn alerts. [![Open-Source Software][oss icon]](https://github.com/tristan666666/agent-island) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Cacher](https://www.cacher.io/) - Cloud-based, team-enabled code snippet manager with Gist sync, VSCode/Atom/Sublime packages and full-featured web client.
 - [ChatCrystal](https://zengliangyi.github.io/ChatCrystal/) - Local-first Windows desktop app that turns AI coding conversations into searchable knowledge notes. [![Open-Source Software][oss icon]](https://github.com/ZengLiangYi/ChatCrystal) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [DB Browser for SQLite](http://sqlitebrowser.org/) - High quality, visual, open source tool to create, design, and edit database files compatible with SQLite [![Open-Source Software][oss icon]](http://sqlitebrowser.org/)


### PR DESCRIPTION
Adds Agent Island to the Developer Tools section in alphabetical order and follows the repository's website, open-source, and freeware link format.

I help run Agent Island. The current public release provides a Windows x64 package and tracks Claude Code and Codex session state with your-turn alerts.