### PR TITLE
Add Flowtake to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 ### Video
 
 - [DaVinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve/) - Professional video creation software for editing, visual effects, color correction, and audio post production. ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [Flowtake](https://jnx03.github.io/Flowtake/) - Local-first screen recorder and timeline editor with local MP4 export. [![Open-Source Software][oss icon]](https://github.com/JNX03/Flowtake)
 - [HandBrake](http://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][oss icon]](https://github.com/HandBrake/HandBrake)
 - [K-Lite Codecs](http://www.codecguide.com/download_kl.htm) - Collection of DirectShow filters, VFW/ACM codecs, and tools.
 - [mpv](http://mpv.io/) - Media player. [![Open-Source Software][oss icon]](https://github.com/mpv-player/mpv)


### PR DESCRIPTION
Adds Flowtake to the Video section in alphabetical order.

The entry uses the public app website as its primary link and the GitHub repository for the open-source symbol, following the contribution guidelines.