### PR TITLE
Add DevProjex to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 - [Cacher](https://www.cacher.io/) - Cloud-based, team-enabled code snippet manager with Gist sync, VSCode/Atom/Sublime packages and full-featured web client.
 - [ChatCrystal](https://zengliangyi.github.io/ChatCrystal/) - Local-first Windows desktop app that turns AI coding conversations into searchable knowledge notes. [![Open-Source Software][oss icon]](https://github.com/ZengLiangYi/ChatCrystal) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [DB Browser for SQLite](http://sqlitebrowser.org/) - High quality, visual, open source tool to create, design, and edit database files compatible with SQLite [![Open-Source Software][oss icon]](http://sqlitebrowser.org/)
+- [DevProjex](https://github.com/Avazbek22/DevProjex) - Selects, previews and exports project trees and file contents for AI chats, code reviews and documentation. [![Open-Source Software][oss icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [ExtendsClass](https://extendsclass.com/) - Online tools for developers (REST/SOAP clients, SQLite browser, Regex tester, XPath tester) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Fiddler](http://www.telerik.com/fiddler) - Web debugging proxy.
 - [FileZilla](https://filezilla-project.org/) - FTP, FTPS and SFTP client. [![Open-Source Software][oss icon]](https://download.filezilla-project.org/client/) ![Freeware][freeware icon] ![Freeware][freeware icon light]


### PR DESCRIPTION
Adds DevProjex to **Developer Tools** in alphabetical order, using the repository and the existing open-source/freeware markers.

Validation: `git diff --check`; the DevProjex repository link returned HTTP 200.
