### PR TITLE
Add BluetoothHandsFreeToggle to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [AIMP](http://www.aimp.ru/) - 32 bit audio processing and multi-format playback. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Audacity](http://audacityteam.org/) - Free, open source, cross-platform software for recording and editing sounds. [![Open-Source Software][oss icon]](https://github.com/audacity/audacity) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [AudioNodes](https://audionodes.com/) - Modular audio production suite with multi-track audio mixing, audio effects, parameter automation, MIDI editing, synthesis, cloud production, and more. ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [BluetoothHandsFreeToggle](https://github.com/Avazbek22/BluetoothHandsFreeToggle) - Fixes low-quality Bluetooth headset audio on Windows when games or voice apps leave the device stuck in Hands-Free mode, with safe reset, disable, and restore options. [![Open-Source Software][oss icon]](https://github.com/Avazbek22/BluetoothHandsFreeToggle) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [CDex](http://www.cdex.fr/) - CD Ripper (French site, English program). ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Dopamine](http://www.digimezzo.com/software/dopamine/) - An audio player which tries to make organizing and listening to music as simple and pretty as possible. ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Exact Audio Copy](http://www.exactaudiocopy.de/) - Transfer files from your CDs to your PC in almost every format.Comes with some pretty nifty features too.


### PR DESCRIPTION
Adds BluetoothHandsFreeToggle to the Audio section. It restores clear Bluetooth stereo when games or voice apps leave a Windows headset stuck in Hands-Free mode.