### PR TITLE
Add FluxDown to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 - [ExifCleaner](https://exifcleaner.com) - Remove exif metadata from images and videos with drag and drop. [![Open-Source Software][oss icon]](https://github.com/szTheory/exifcleaner) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Far](http://www.farmanager.com/index.php?l=en) - File and Archive manager. Clone of the Norton Commander. [![Open-Source Software][oss icon]](http://sourceforge.net/projects/farmanager/)
 - [FileOptimizer](https://nikkhokkho.sourceforge.io/static.php?page=FileOptimizer) - A lossless file size optimizer supporting a wide array of formats.
+- [FluxDown](https://fluxdown.zerx.dev) - Multi-protocol download manager with IDM-style dynamic segmentation for HTTP, FTP, BitTorrent, eD2K, HLS and DASH. [![Open-Source Software][oss icon]](https://github.com/zerx-lab/FluxDown) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Fraps](http://www.fraps.com/)- Video game capture screen recorder that can be used with all games using DirectX or OpenGL technology.
 - [FreeFileSync](http://www.freefilesync.org/) - An easy backup solution for files and folders, It supports mirroring/two way sync/update between source and destination.
 - [fselect](https://github.com/jhspetersson/fselect) - Command-line tool to search files with SQL-like queries.


### PR DESCRIPTION
FluxDown is a free and open-source download manager for Windows (x64 and ARM64). It covers HTTP/HTTPS, FTP, BitTorrent, eD2K, HLS and DASH, splits downloads into segments dynamically like IDM does, and ships Chrome/Edge/Firefox extensions for intercepting browser downloads.

- Site: https://fluxdown.zerx.dev
- Source: https://github.com/zerx-lab/FluxDown (AGPL-3.0)

There is no downloads category, so I put it under Utilities in alphabetical order, between FileOptimizer and Fraps. OSS icon links to the source, the primary link points to the site.