### PR TITLE
Add AI Dictation to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@
 
 ### Productivity
 
+- [AI Dictation](https://aidictation.com) - Voice-to-text app with a configurable global shortcut for supported Windows applications. [![Open-Source Software][oss icon]](https://github.com/writingmate/aidictation)
 - [Aperture Control](https://github.com/Lieturd/aperture-control) - Windows environment automation tool with a number of [premade recipes](https://github.com/Lieturd/aperture-control-recipes) and [examples](https://github.com/Lieturd/aperture-control-example) available. [![Open-Source Software][oss icon]](https://github.com/Lieturd/aperture-control) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [AutoHotkey](https://autohotkey.com/) - The ultimate automation scripting language for Windows. [![Open-Source Software][oss icon]](https://autohotkey.com/) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Beetroot](https://max.nardit.com/beetroot) - Clipboard manager with AI text transforms and OCR extraction. ![Freeware][freeware icon] ![Freeware][freeware icon light]


### PR DESCRIPTION
## Summary

- Add AI Dictation to the Productivity section in alphabetical order.
- Link the product website as the primary URL and its MIT-licensed native-client source through the OSS badge.
- Keep the description limited to verified Windows behavior and omit a freeware badge.

## Why it fits

AI Dictation has a released Windows client that provides voice-to-text input through a configurable global shortcut in supported Windows applications. The repository publishes a Windows installer and portable ZIP.

## Verification

- Searched the list and open/closed pull requests and issues for AI Dictation, aidictation.com, WhisperMate, and Writingmate; no prior submission was found.
- Confirmed the public Windows client source and MIT license: https://github.com/writingmate/aidictation
- Confirmed the current Windows release assets: https://github.com/writingmate/aidictation/releases/tag/windows-v0.0.5
- Confirmed both links return HTTP 200 and ran `git diff --check`.

Disclosure: I am affiliated with AI Dictation. This submission and its verification were prepared with AI assistance and reviewed by me.
