### PR TITLE
Add PinkDown to Text Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@
 - [Notepad++](https://notepad-plus-plus.org/) - A source code editor which supports several programming languages. [![Open-Source Software][oss icon]](https://github.com/notepad-plus-plus/notepad-plus-plus) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Notepad2](http://www.flos-freeware.ch/notepad2.html) - Tiny and fast Notepad replacement with many useful features. ![Open-Source Software][oss icon] ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Oni](http://onivim.io/) - Modern Modal Editing - powered by Neovim [![Open-Source Software][oss icon]](https://github.com/onivim/oni) ![Freeware][freeware icon] ![Freeware][freeware icon light]
+- [PinkDown](https://3xian.github.io/PinkDown/) - Fast native split-pane Markdown editor and reader for Windows, built in Rust. [![Open-Source Software][oss icon]](https://github.com/3xian/PinkDown) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [SpaceVim](https://spacevim.org) - A community-driven vim distribution [![Open-Source Software][oss icon]](https://github.com/onivim/oni) ![Freeware][freeware icon] ![Freeware][freeware icon light]
 - [Sublime Text 3](http://www.sublimetext.com/3) - The sophisticated text editor.
 - [Visual Studio Code](https://code.visualstudio.com/) - Build and debug modern web and cloud applications. [![Open-Source Software][oss icon]](https://github.com/Microsoft/vscode) ![Freeware][freeware icon] ![Freeware][freeware icon light]


### PR DESCRIPTION
Adds [PinkDown](https://3xian.github.io/PinkDown/) to the Text Editors section in alphabetical order.

PinkDown is a free, MIT-licensed native Markdown editor and reader for Windows, built in Rust. It provides a split-pane source and live-preview workflow, supports UTF-8 and UTF-16 files, drag-and-drop opening, and ships a Windows x64 installer.

Source: https://github.com/3xian/PinkDown